### PR TITLE
Fix accelerators domain spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# acclerators.club — Web3 & AI Directory
+# accelerators.club — Web3 & AI Directory
 
 Zero-backend, Next.js 14 + Tailwind directory to list Web3 projects, AI startups, and investors.
 Search + filters + local CSV/JSON import (saved to your browser).
@@ -24,4 +24,4 @@ npm run dev
 
 ## Notes
 - No backend. Perfect for a lightweight public directory.
-- You can attach a custom domain `acclerators.club` in Vercel's Dashboard after deploy.
+- You can attach a custom domain `accelerators.club` in Vercel's Dashboard after deploy.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,15 +3,15 @@ import "./globals.css";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "acclerators.club — Web3 & AI Directory",
+  title: "accelerators.club — Web3 & AI Directory",
   description: "Curated directory of Web3 projects, AI startups, and investors.",
   openGraph: {
-    title: "acclerators.club — Web3 & AI Directory",
+    title: "accelerators.club — Web3 & AI Directory",
     description: "Curated directory of Web3 projects, AI startups, and investors.",
     type: "website",
-    url: "https://acclerators.club",
+    url: "https://accelerators.club",
   },
-  metadataBase: new URL("https://acclerators.club")
+  metadataBase: new URL("https://accelerators.club")
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/components/Home.tsx
+++ b/components/Home.tsx
@@ -137,7 +137,7 @@ export default function Home() {
       </section>
 
       <footer className="opacity-80 text-center pb-8">
-        <p className="text-sm">© {new Date().getFullYear()} acclerators.club • Built with Next.js</p>
+        <p className="text-sm">© {new Date().getFullYear()} accelerators.club • Built with Next.js</p>
       </footer>
     </main>
   );

--- a/components/Logo.tsx
+++ b/components/Logo.tsx
@@ -2,7 +2,7 @@
 export default function Logo() {
   return (
     <div className="text-xl sm:text-2xl md:text-3xl font-bold tracking-tight">
-      <span className="opacity-80">acclerators</span>
+      <span className="opacity-80">accelerators</span>
       <span className="opacity-60">.</span>
       <span className="text-brand-400">club</span>
     </div>

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "acclerators-club",
+  "name": "accelerators-club",
   "version": "1.0.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary
- correct accelerators.club spelling across docs, components, and metadata

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run build` *(fails: Syntax Error in components/Card.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_689ca67b8d90832ebf37a21e22df0981