### PR TITLE
fix: handle missing cheque values

### DIFF
--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -30,10 +30,10 @@ export function InvestorCard({ i }: { i: Investor }) {
   const max = i.chequeMaxUSD ?? null;
   const cheque = min != null || max != null
     ? min != null && max != null
-      ? `$${min / 1000}k – $${max / 1000}k`
+      ? `$${(min ?? 0) / 1000}k – $${(max ?? min ?? 0) / 1000}k`
       : min != null
-        ? `$${min / 1000}k+`
-        : `Up to $${max! / 1000}k`
+        ? `$${(min ?? 0) / 1000}k+`
+        : `Up to $${(max ?? min ?? 0) / 1000}k`
     : null;
   return (
     <a href={i.url} target="_blank" rel="noreferrer"


### PR DESCRIPTION
## Summary
- ensure cheque string handles missing min and max values using nullish coalescing

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cbc50f55c832e8539a363d3c117d9