### PR TITLE
style: enhance glass styles with stronger gradients

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -14,17 +14,31 @@ html, body, #__next { height: 100%; }
 body {
   @apply bg-slate-900 text-white;
   background:
-    radial-gradient(60rem 60rem at 20% -10%, rgba(59,130,246,.2), transparent 60%),
-    radial-gradient(50rem 50rem at 110% 10%, rgba(236,72,153,.15), transparent 60%),
-    radial-gradient(40rem 40rem at -10% 110%, rgba(52,211,153,.15), transparent 60%);
+    radial-gradient(60rem 60rem at 20% -10%, rgba(59,130,246,.3), transparent 60%),
+    radial-gradient(50rem 50rem at 110% 10%, rgba(236,72,153,.2), transparent 60%),
+    radial-gradient(40rem 40rem at -10% 110%, rgba(52,211,153,.2), transparent 60%);
 }
 
 .glass {
-  @apply rounded-2xl shadow-glass border border-white/10;
-  background: linear-gradient(135deg, rgba(255,255,255,0.12), rgba(255,255,255,0.06));
-  backdrop-filter: blur(12px);
+  @apply rounded-2xl shadow-glass border border-white/20;
+  background: linear-gradient(135deg, rgba(255,255,255,0.25), rgba(255,255,255,0.1));
+  backdrop-filter: blur(12px) saturate(150%) brightness(110%);
+  transition: background 0.3s ease, border-color 0.3s ease, backdrop-filter 0.3s ease;
 }
 
-.chip { @apply text-xs px-2 py-1 rounded-full border border-white/10 bg-white/5; }
-.pill { @apply px-3 py-1.5 rounded-full bg-white/10 hover:bg-white/15 transition; }
+.glass:hover {
+  @apply border-white/30;
+  background: linear-gradient(135deg, rgba(255,255,255,0.35), rgba(255,255,255,0.15));
+  backdrop-filter: blur(14px) saturate(180%) brightness(115%);
+}
+
+.glass:active {
+  @apply border-white/40;
+  backdrop-filter: blur(16px) saturate(200%) brightness(120%);
+}
+
+.chip { @apply text-xs px-2 py-1 rounded-full border border-white/15 bg-white/5 transition-colors; }
+.chip:hover { @apply bg-white/10; }
+.chip:active { @apply bg-white/15; }
+.pill { @apply px-3 py-1.5 rounded-full bg-white/10 hover:bg-white/15 active:bg-white/20 transition; }
 .section { @apply glass p-5 md:p-8; }


### PR DESCRIPTION
## Summary
- intensify page background gradients for richer depth
- revamp glass surfaces with brighter borders, backdrop filters, and hover/active transitions
- add smooth color transitions to chip and pill components

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint setup)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cbc595c8c832e8f8c92db9b023963